### PR TITLE
Debian support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,33 @@
 2. Install [Meson](https://mesonbuild.com).
 
 3. Install the following:
-    - `arm-none-eabi-gcc`
-    - `arm-none-eabi-binutils`
-    - `arm-none-eabi-newlib` (optional, for libc functions)
-    - `arm-none-eabi-gdb` (recommended, for debugging)
-    - `openocd` (recommended, for flashing)
+    1. For Arch derivatives:
+        - `arm-none-eabi-gcc`
+        - `arm-none-eabi-binutils`
+        - `arm-none-eabi-newlib` (optional, for libc functions)
+        - `arm-none-eabi-gdb` (recommended, for debugging)
+        - `openocd` (recommended, for flashing)
+    2. For debian derivatives:
+        - `gcc-arm-none-eabi`
+        - `binutils-arm-none-eabi`
+        - `libnewlib-arm-none-eabi`
+        - `gdb-multiarch` (includes arm-none-eabi)
+        - `openocd`
+4. (Optional) In the event that flashing fails, you may need to add some udev rules:
+    1. As root, create three files under `/etc/udev/rules.d` with the following names and contents:
+        - `45-mbed_debugger.rules`
+            ~~~SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE="0660", GROUP="plugdev"~~~
+        - `50-tty_cmsis.rules`
+            ~~~KERNEL=="ttyACM[0 ... 9]" SYMLINK+="%k" GROUP="plugdev" MODE="0660"~~~
+        - `99-hidraw-permissions.rules`
+            ~~~KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"~~~
+    2. Create the plugdev group, if it does not exist:
+        ~~~sudo getent group plugdev || sudo groupadd plugdev~~~
+    3. Add your user to the plugdev group:
+        ~~~sudo usermod -aG plugdev $USER~~~
+    4. And finally, reload the udev rules:
+        ~~~sudo udevadm control --reload-rules~~~
+
 
 ## Building Your Project
 1. Customize the `meson.build` file to include the files for your project.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
         - `arm-none-eabi-newlib` (optional, for libc functions)
         - `arm-none-eabi-gdb` (recommended, for debugging)
         - `openocd` (recommended, for flashing)
-    2. For debian derivatives:
+    2. For Debian derivatives:
         - `gcc-arm-none-eabi`
         - `binutils-arm-none-eabi`
         - `libnewlib-arm-none-eabi`
@@ -55,6 +55,7 @@
     4. And finally, reload the udev rules:
         ```
         sudo udevadm control --reload-rules
+        sudo udevadm trigger
         ```
 
 

--- a/README.md
+++ b/README.md
@@ -33,17 +33,29 @@
 4. (Optional) In the event that flashing fails, you may need to add some udev rules:
     1. As root, create three files under `/etc/udev/rules.d` with the following names and contents:
         - `45-mbed_debugger.rules`
-            ~~~SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE="0660", GROUP="plugdev"~~~
+            ```
+            SUBSYSTEM=="usb", ATTR{idVendor}=="0d28", ATTR{idProduct}=="0204", MODE="0660", GROUP="plugdev"
+            ```
         - `50-tty_cmsis.rules`
-            ~~~KERNEL=="ttyACM[0 ... 9]" SYMLINK+="%k" GROUP="plugdev" MODE="0660"~~~
+            ```
+            KERNEL=="ttyACM[0 ... 9]" SYMLINK+="%k" GROUP="plugdev" MODE="0660"
+            ```
         - `99-hidraw-permissions.rules`
-            ~~~KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"~~~
+            ```
+            KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev" 
+            ```
     2. Create the plugdev group, if it does not exist:
-        ~~~sudo getent group plugdev || sudo groupadd plugdev~~~
+        ```
+        sudo getent group plugdev || sudo groupadd plugdev
+        ```
     3. Add your user to the plugdev group:
-        ~~~sudo usermod -aG plugdev $USER~~~
+        ```
+        sudo usermod -aG plugdev $USER
+        ```
     4. And finally, reload the udev rules:
-        ~~~sudo udevadm control --reload-rules~~~
+        ```
+        sudo udevadm control --reload-rules
+        ```
 
 
 ## Building Your Project

--- a/scripts/gdb.sh
+++ b/scripts/gdb.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 WHERE=$(dirname $0)
+gdbarm=$(arm-none-eabi-gdb -version 2>/dev/null)
+gdbmulti=$(gdb-multiarch -version 2>/dev/null)
 source $WHERE/openocd_server.sh
 start_oocd
-arm-none-eabi-gdb --eval-command="target remote localhost:3333" $1
+if [ ! -z "$gdbarm" ]; then
+    arm-none-eabi-gdb --eval-command="target remote localhost:3333" $1
+elif [ ! -z "$gdbmulti" ]; then 
+    gdb-multiarch --eval-command="set architecture armv6" --eval-command="target remote localhost:3333" $1
+else
+    echo "no suitable gdb found"
+    stop_oocd
+fi


### PR DESCRIPTION
Mostly updated README.md to include information for getting set up on debian, ended up including udev notes here as well to keep the spirit of the template. 

Modified gdb.sh debugging script to work with either gdb-multiarch or arm-none-eabi-gdb, depending on what's installed. 