### PR TITLE
updates the flash script to allow argument binary

### DIFF
--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -2,5 +2,9 @@
 WHERE=$(dirname $0)
 source $WHERE/openocd_server.sh
 start_oocd
-(echo "init;kinetis mdm mass_erase 0;reset halt;flash write_image build/main.bin 0 bin;reset run; exit"; sleep 1; echo "quit")| telnet localhost 4444
+if [[ -n $1 ]]; then
+    (echo "init;kinetis mdm mass_erase 0;reset halt;flash write_image $1 0 bin;reset run; exit"; sleep 1; echo "quit")| telnet localhost 4444
+else
+    (echo "init;kinetis mdm mass_erase 0;reset halt;flash write_image $(pwd)/build/main.bin 0 bin;reset run; exit"; sleep 1; echo "quit")| telnet localhost 4444
+fi
 


### PR DESCRIPTION
I added a switch to check if an argument file was passed to the script. This allows passing in binary files to flash, such as provided binaries. If no argument is given, it simply uses the binary (if it exists) located in `$(pwd)/build/main.bin` as a fallback. 